### PR TITLE
Infrastructure for a bikeshed-based spec.

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,15 @@
+name: CI
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+jobs:
+  main:
+    name: Build, Validate and Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          SOURCE: permission-element.bs
+          GH_PAGES_BRANCH: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.ninja_log
+permission-element.html

--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,0 +1,4 @@
+{
+    "src_file": "permission-element.bs",
+    "type": "bikeshed"
+}

--- a/build.ninja
+++ b/build.ninja
@@ -1,0 +1,6 @@
+rule bikeshed
+  command = bikeshed --print=plain -f spec $in
+  description = bikeshed $in
+
+build permission-element.html: bikeshed permission-element.bs
+default permission-element.html

--- a/permission-element.bs
+++ b/permission-element.bs
@@ -1,0 +1,25 @@
+<pre class="metadata">
+Title: The HTML &lt;permission&gt; Element
+Status: CG-DRAFT
+Group: WICG
+URL: https://wicg.github.io/PEPC/permission-element.html
+Repository: WICG/PEPC
+Shortname: pepc
+Level: 0
+Boilerplate: omit conformance
+Markup Shorthands: markdown on
+Editor: Daniel Vogelheim, Google LLC, vogelheim@google.com, https://www.google.com/
+Editor: Andy Paicu, Google LLC
+Abstract: A `<permission>` HTML element to request browser permissions in-page.
+
+  Suitable styling and UI constraints on this new element ensure that the user
+  understands what a click on it means, and thus gives the browser a high level
+  of confidence of user intent to make a permission decision.
+  The `<permission>` element aims to be more accessible and more secure than
+  the current permission flows.
+</pre>
+
+# Introduction # {#intro}
+# Framework # {#framwork}
+# Algorithms # {#algorithms}
+# Security & Privacy Considerations # {#secpriv}


### PR DESCRIPTION
This lands some infrastructure for a future, bikeshed-based spec. The spec itself is a placeholder for now.

- auto-publish.yml: A workflow to build & publish the spec to GitHub pages.
- .pr-preview.json: Hook into a mechanism to auto-attach previews to GitHub pull requests.
- build.ninja: Ninja file to run bikeshed.
- permission-element.bs: A mostly empty bikeshed spec.
- .gitignore: Ignore file to ignore build artefacts in commits (and thus pull requests).