### PR TITLE
Spec: Add HTMLPermissionElement.isTypeSupported static operation.

### DIFF
--- a/permission-element.bs
+++ b/permission-element.bs
@@ -138,6 +138,8 @@ time providing implementations with a better signal of user intent.
       readonly attribute boolean isValid;
       readonly attribute PermissionElementBlockerReason invalidReason;
 
+      static boolean isTypeSupported(DOMString type);
+
       attribute EventHandler onpromptaction;
       attribute EventHandler onpromptdismiss;
       attribute EventHandler onvalidationstatuschange;
@@ -165,6 +167,15 @@ permission element is not currently blocked.
 The {{HTMLPermissionElement/invalidReason}} attribute is an
 [=enumerated attribute=] that reflects the internal state of the permission
 element. It's value set are {{PermissionElementBlockerReason}}
+
+The {{HTMLPermissionElement/isTypeSupported}} [=static operation=] whether a
+gives {{HTMLPermissionElement/type}}, that is, a given
+[=enumerated attribute|enumeration=] of [=powerful features=], is supported.
+It predicts whether creating a <{permission}> element and assigning the given
+{{HTMLPermissionElement/type}} string will work, or whether it will create
+an element blocked by a {{PermissionElementBlockerReason/type_invalid}}
+[=permanent blocker=].
+
 
 The global <a attribute spec=html for=HTMLElement>lang</a> attribute is
 observed by the <{permission}> element to select localized text.
@@ -276,12 +287,35 @@ The HTMLPermissionElement's {{HTMLPermissionElement/type}} setter steps are:
 
 1. If {{[[Types]]}} is not null: Return.
 1. Set {{[[Types]]}} to &laquo;[]&raquo;.
-1. Parse the input as a string of [=powerful feature=] names, seperated by whitespace.
-1. If any errors occured, return.
-1. Check if the set of [=powerful features=] is supported for the {{HTMLPermissionElement}} by the [=user agent=]. If not, return.
+1. Let |features| be the result of calling [=parse a type string=] with the
+    input string.
+1. If |features| is None, return.
 1. [=list/Append=] each [=powerful feature=] name to the {{[[Types]]}} [=ordered set=].
 
 Note: The supported sets of [=powerful features=] is [=implementation-defined=].
+</div>
+
+To query whether a feature (or group of features) is supported:
+
+<div algorithm="HTMLPermissionElement/isTypeSupported()">
+HTMLPermissionElement's {{HTMLPermissionElement/isTypeSupported()}} method
+steps with argument with {{DOMString}} |type|are:
+
+1. Let |features| be the result of calling [=parse a type string=] with |type|.
+1. Return whether |features| is not None.
+
+</div>
+
+<div algorithm>
+To <dfn>parse a type string</dfn> a given string |type|:
+
+1. Let |list| be the result of parsing |type| as a string of
+    [=powerful feature=] names, seperated by whitespace.
+1. If any errors occured, return None.
+1. Check if the set of [=powerful features=] is supported for the
+    {{HTMLPermissionElement}} by the [=user agent=]. If not, return None.
+1. Return |list|.
+
 </div>
 
 ### Activation blockers ### {#permission-element-activation-blockers}


### PR DESCRIPTION
Specify support for PEPC Feature Detection.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/PEPC/pull/46.html" title="Last updated on May 9, 2025, 12:49 PM UTC (ab4c8ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/PEPC/46/559cc4d...otherdaniel:ab4c8ef.html" title="Last updated on May 9, 2025, 12:49 PM UTC (ab4c8ef)">Diff</a>