### PR TITLE
Prepare for joined permission elements spec.

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -14,6 +14,11 @@ jobs:
           SOURCE: permission-element.bs
           TOOLCHAIN: bikeshed
           GH_PAGES_BRANCH: gh-pages
+      - uses: w3c/spec-prod@v2
+        with:
+          SOURCE: permission-elements.bs
+          TOOLCHAIN: bikeshed
+          GH_PAGES_BRANCH: gh-pages
   copy_demo:
     name: Copy demo page to gh-pages
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .ninja_log
 .ninja_log.last_upload
 permission-element.html
+permission-elements.html

--- a/build.ninja
+++ b/build.ninja
@@ -3,4 +3,5 @@ rule bikeshed
   description = bikeshed $in
 
 build permission-element.html: bikeshed permission-element.bs
-default permission-element.html
+build permission-elements.html: bikeshed permission-elements.bs
+default permission-elements.html

--- a/permission-elements.bs
+++ b/permission-elements.bs
@@ -1,0 +1,6 @@
+<pre class="metadata">
+Title: The HTML Permission Elements
+Shortname: pepc
+Status: DREAM
+Abstract: Just a placeholder, for now.
+</pre>


### PR DESCRIPTION
To accomodate <geolocation> & other elements, we rename the spec from permission-element to permission-elements. This adds an empty permission-elements.bs, and adds the required build steps.