### PR TITLE
Link to new Permission Elements spec from the main README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,23 @@
+# HTML Permission Elements
+
+This repo documents a number of proposed HTML elements, whose common goal is
+to provide secure and user friendly access and control of
+[HTML permissions](https://www.w3.org/TR/permissions/) and their associated
+capabilities from within a web page.
+
+# Geolocation Element
+
+An HTML permission element for the
+[geolocation](https://www.w3.org/TR/geolocation/) feature:
+
+* [Explainer](geolocation_explainer.md)
+* [Joined Permission Elements specification draft](https://wicg.github.io/PEPC/permission-elements.html)
+
 # Page Embedded Permission Control (PEPC)
+
+The originally proposed permission element, for any
+[permission](https://www.w3.org/TR/permissions/)
 
 * [Explainer for PEPC](explainer.md)
 * [Specification draft](https://wicg.github.io/PEPC/permission-element.html)
-
-# Geolocation element
-* [Explainer](geolocation_explainer.md)
+   (as of Sept 22, 2025)

--- a/permission-element.bs
+++ b/permission-element.bs
@@ -1,6 +1,6 @@
 <pre class="metadata">
 Title: The HTML &lt;permission&gt; Element
-Status: CG-DRAFT
+Status: UD
 Group: WICG
 URL: https://wicg.github.io/PEPC/permission-element.html
 Repository: WICG/PEPC
@@ -79,6 +79,11 @@ dl, dd { padding-left: .5em; }
 /* vars in italics */
 dfn var { font-style: italic; }
 </style>
+
+NOTE: This draft has been superseded by
+[HTML Permission Elements](permission-elements.html), which deconstructs the
+<{permission}> element described here into a family of elements, each targeting
+a specific permission and use case.
 
 # Introduction # {#intro}
 


### PR DESCRIPTION
- Link to permission-elements spec (which includes <geolocation>).
- Deprecate the original permission-element spec (only PEPC).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/PEPC/pull/72.html" title="Last updated on Oct 9, 2025, 12:57 PM UTC (600582c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/PEPC/72/9a150b4...otherdaniel:600582c.html" title="Last updated on Oct 9, 2025, 12:57 PM UTC (600582c)">Diff</a>