### PR TITLE
Make `position` and `error` nullable.

### DIFF
--- a/permission-elements.bs
+++ b/permission-elements.bs
@@ -1245,8 +1245,8 @@ The {{HTMLGeolocationElement}} <dfn constructor for=HTMLGeolocationElement>const
 1. Initialize the internal {{[[watchIDs]]}} to &laquo; |watchID| &raquo;, where
     |watchID| is an [=implementation-defined=] {{unsigned long}} that is
     greater than zero.
-1. Initialize the internal {{[[position]]}} to `null`.
-1. Initialize the internal {{[[positionError]]}} to `null`.
+1. Initialize the internal {{[[position]]}} to null.
+1. Initialize the internal {{[[positionError]]}} to null.
 
 </div>
 


### PR DESCRIPTION
I think the intent here matches WebIDL's "nullable" concept, which also happens to line up with Chromium's current behavior (which returns `null` rather than `undefined` if a position hasn't yet been obtained).