### PR TITLE
Make geolocation-element.bs "official".

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -16,11 +16,6 @@ jobs:
           GH_PAGES_BRANCH: gh-pages
       - uses: w3c/spec-prod@v2
         with:
-          SOURCE: permission-elements.bs
-          TOOLCHAIN: bikeshed
-          GH_PAGES_BRANCH: gh-pages
-      - uses: w3c/spec-prod@v2
-        with:
           SOURCE: geolocation-element.bs
           TOOLCHAIN: bikeshed
           GH_PAGES_BRANCH: gh-pages

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An HTML permission element for the
 [geolocation](https://www.w3.org/TR/geolocation/) feature:
 
 * [Explainer](geolocation_explainer.md)
-* [Joined Permission Elements specification draft](https://wicg.github.io/PEPC/permission-elements.html)
+* [Geolocation Element Specification Draft](https://wicg.github.io/PEPC/geolocation-element.html)
 
 # Page Embedded Permission Control (PEPC)
 
@@ -19,5 +19,5 @@ The originally proposed permission element, for any
 [permission](https://www.w3.org/TR/permissions/)
 
 * [Explainer for PEPC](explainer.md)
-* [Specification draft](https://wicg.github.io/PEPC/permission-element.html)
+* [Permission Element Specification draft](https://wicg.github.io/PEPC/permission-element.html)
    (as of Sept 22, 2025)

--- a/build.ninja
+++ b/build.ninja
@@ -3,6 +3,5 @@ rule bikeshed
   description = bikeshed $in
 
 build permission-element.html: bikeshed permission-element.bs
-build permission-elements.html: bikeshed permission-elements.bs
 build geolocation-element.html: bikeshed geolocation-element.bs
-default permission-element.html permission-elements.html geolocation-element.html
+default permission-element.html geolocation-element.html


### PR DESCRIPTION
Remove the joint permission-elements spec. (The rendered version stays in the gh-pages branch for now.)
Instead, link to the geolocation-element spec directly.