### PR TITLE
Do not use class=elements for non-element definitions.

### DIFF
--- a/geolocation-element.bs
+++ b/geolocation-element.bs
@@ -447,23 +447,27 @@ This section defines several mixins and supporting algorithms.
 ## Activation Blockers ## {#mixin-blockers}
 
 To support a meaningful user intent signal and to conditionally block element
-activation, you can use the {{ActivationBlockersMixin}}
+activation, you can use the {{ActivationBlockersMixin}}. It is defined as
+follows:
 
-<dl class="element">
- <dt>[=Content attributes=]:</dt>
-  <dd>{{ActivationBlockersMixin/isValid}} — query whether the element can currently be activated.</dd>
-  <dd>{{ActivationBlockersMixin/invalidReason}} — return a string representation of why the element currently cannot be activated.</dd>
-  <dd>{{ActivationBlockersMixin/onvalidationstatuschange}} — notifies when the validation status changes.</dd>
- <dt>[=DOM interface=]:</dt>
-  <dd>
-   <pre class=idl>
-    interface mixin ActivationBlockersMixin {
-      readonly attribute boolean isValid;
-      readonly attribute ActivationBlockersMixinBlockerReason invalidReason;
-      attribute EventHandler onvalidationstatuschange;
-    };
-   </pre>
-  </dd>
+<pre class=idl>
+interface mixin ActivationBlockersMixin {
+  readonly attribute boolean isValid;
+  readonly attribute ActivationBlockersMixinBlockerReason invalidReason;
+  attribute EventHandler onvalidationstatuschange;
+};
+</pre>
+
+Elements using the {{ActivationBlockersMixin}} are expected to support the
+following [=content attributes=]:
+
+<dl>
+  <dt>{{ActivationBlockersMixin/isValid}}</dt>
+  <dd>query whether the element can currently be activated.</dd>
+  <dt>{{ActivationBlockersMixin/invalidReason}}</dt>
+  <dd>return a string representation of why the element currently cannot be activated.</dd>
+  <dt>{{ActivationBlockersMixin/onvalidationstatuschange}}</dt>
+  <dd>notifies when the validation status changes.</dd>
 </dl>
 
 
@@ -609,7 +613,7 @@ These blockers come with three lifetimes: Permanent, temporary, and expiring.
 
 
 
-### Algorithms ### {#mixin-blockers-algoreithms}
+### Algorithms ### {#mixin-blockers-algorithms}
 
 <div algorithm>
 To <dfn for="ActivationBlockersMixin">add a blocker</dfn> with a
@@ -788,21 +792,16 @@ ISSUE: Do I need to define dictionary equality?
 ## Powerful Features, aka Permissions ## {#mixin-permissions}
 
 To support elements that gate access to [=powerful features=], you can use the
-{{PowerfulFeatureObserver}}.
+{{PowerfulFeatureObserver}}. It is defined as follows:
 
-<dl class="element">
- <dt>[=DOM interface=]:</dt>
-  <dd>
-   <pre class=idl>
-    interface mixin PowerfulFeatureObserver {
-      readonly attribute PermissionState initialPermissionStatus;
-      readonly attribute PermissionState permissionStatus;
-      attribute EventHandler onpromptaction;
-      attribute EventHandler onpromptdismiss;
-    };
-   </pre>
-  </dd>
-</dl>
+<pre class=idl>
+interface mixin PowerfulFeatureObserver {
+  readonly attribute PermissionState initialPermissionStatus;
+  readonly attribute PermissionState permissionStatus;
+  attribute EventHandler onpromptaction;
+  attribute EventHandler onpromptdismiss;
+};
+</pre>
 
 The following are the [=event handlers=] (and their corresponding [=event handler event types=]) that must be supported on elements that include the {{PowerfulFeatureObserver}}:
 <pre class=simpledef>

--- a/permission-elements.bs
+++ b/permission-elements.bs
@@ -120,30 +120,35 @@ The elements in this specification exhibit a number of common behaviours, which
 are captured by the {{InPagePermissionMixin}} and its associated state,
 algorithms, and rendering rules.
 
-<dl class="element">
- <dt>[=Content attributes=]:</dt>
-  <dd>{{InPagePermissionMixin/isValid}} — query whether the element can currently be activated.</dd>
-  <dd>{{InPagePermissionMixin/invalidReason}} — return a string representation of why the element currently cannot be activated.</dd>
-  <dd>{{InPagePermissionMixin/onpromptdismiss}} — notifies when the user has dismissed a permission prompt that resulted from an interaction with the element</dd>
-  <dd>{{InPagePermissionMixin/onpromptaction}} — notifies when a permission prompt that resulted from an interaction with the element has been answered by the user (positively or negatively).</dd>
-  <dd>{{InPagePermissionMixin/onvalidationstatuschange}} — notifies when the validation status changes.</dd>
- <dt>[=Accessibility considerations=]:</dt>
-  <dd>TODO</dd>
- <dt>[=DOM interface=]:</dt>
-  <dd>
-   <pre class=idl>
-    interface mixin InPagePermissionMixin {
-      readonly attribute boolean isValid;
-      readonly attribute InPagePermissionMixinBlockerReason invalidReason;
-      readonly attribute PermissionState initialPermissionStatus;
-      readonly attribute PermissionState permissionStatus;
+The {{InPagePermissionMixin}} interface mixin is defined as follows:
 
-      attribute EventHandler onpromptaction;
-      attribute EventHandler onpromptdismiss;
-      attribute EventHandler onvalidationstatuschange;
-    };
-   </pre>
-  </dd>
+<pre class=idl>
+interface mixin InPagePermissionMixin {
+  readonly attribute boolean isValid;
+  readonly attribute InPagePermissionMixinBlockerReason invalidReason;
+  readonly attribute PermissionState initialPermissionStatus;
+  readonly attribute PermissionState permissionStatus;
+
+  attribute EventHandler onpromptaction;
+  attribute EventHandler onpromptdismiss;
+  attribute EventHandler onvalidationstatuschange;
+};
+</pre>
+
+Elements using this mixin are expected to support the following
+[=Content attributes=]:
+
+<dl>
+  <dt>{{InPagePermissionMixin/isValid}}</dt>
+  <dd>query whether the element can currently be activated.</dd>
+  <dt>{{InPagePermissionMixin/invalidReason}}</dt>
+  <dd>return a string representation of why the element currently cannot be activated.</dd>
+  <dt>{{InPagePermissionMixin/onpromptdismiss}}</dt>
+  <dd>notifies when the user has dismissed a permission prompt that resulted from an interaction with the element</dd>
+  <dt>{{InPagePermissionMixin/onpromptaction}}</dt>
+  <dd>notifies when a permission prompt that resulted from an interaction with the element has been answered by the user (positively or negatively).</dd>
+  <dt>{{InPagePermissionMixin/onvalidationstatuschange}}</dt>
+  <dd>notifies when the validation status changes.</dd>
 </dl>
 
 The {{InPagePermissionMixin/isValid}} attribute reflects whether a the
@@ -800,7 +805,7 @@ Note: The <{permission}> element is the original proposed in-page permission
 
 The <{permission}> element can request arbitrary [=powerful features=].
 
-<dl class="element">
+<dl class=element>
  <dt>[=Categories=]:</dt>
   <dd>[=Flow content=].</dd>
   <dd>[=Phrasing content=].</dd>


### PR DESCRIPTION
We used `class=element` tables for interface definitions, because they're pretty. We remove this usage, and use `class=element` only for element definitions.

Per https://github.com/w3c/browser-specs/issues/2107#issuecomment-3742396722 this confuses the webref crawler.